### PR TITLE
feat: Update .gitignore to ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 .settings
 .springBeans
 .sts4-cache
+.claude/
 
 ### IntelliJ IDEA ###
 .idea


### PR DESCRIPTION
Added .claude directory to .gitignore to prevent accidental commits of Claude-related files.