### PR TITLE
feat: Add book filters and password change endpoint

### DIFF
--- a/src/main/java/com/lassriver/bookworm/controllers/BookController.java
+++ b/src/main/java/com/lassriver/bookworm/controllers/BookController.java
@@ -20,10 +20,13 @@ public class BookController {
 
     @GetMapping
     public ResponseEntity<PageResponse<BookResponse>> getBooks(
+            @RequestParam(required = false) String search,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) String category,
+            @RequestParam(required = false) String language,
+            @RequestParam(required = false) String status,
             Pageable pageable) {
-        return ResponseEntity.ok(PageResponse.from(bookService.getBooks(title, category, pageable)));
+        return ResponseEntity.ok(PageResponse.from(bookService.getBooks(search, title, category, language, status, pageable)));
     }
 
     @GetMapping("/{id}")
@@ -43,7 +46,9 @@ public class BookController {
     }
 
     @PatchMapping("/{id}/status")
-    public ResponseEntity<BookResponse> deactivateBook(@PathVariable Long id) {
-        return ResponseEntity.ok(bookService.deactivateBook(id));
+    public ResponseEntity<BookResponse> updateBookStatus(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "INACTIVE") String status) {
+        return ResponseEntity.ok(bookService.updateBookStatus(id, status));
     }
 }

--- a/src/main/java/com/lassriver/bookworm/controllers/UserController.java
+++ b/src/main/java/com/lassriver/bookworm/controllers/UserController.java
@@ -1,5 +1,6 @@
 package com.lassriver.bookworm.controllers;
 
+import com.lassriver.bookworm.dtos.request.PasswordChangeRequest;
 import com.lassriver.bookworm.dtos.request.UserProfileUpdateRequest;
 import com.lassriver.bookworm.dtos.response.UserProfileResponse;
 import com.lassriver.bookworm.services.UserService;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,5 +33,13 @@ public class UserController {
             @Valid @RequestBody UserProfileUpdateRequest request,
             @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(userService.updateCurrentProfile(userDetails.getUsername(), request));
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePassword(
+            @Valid @RequestBody PasswordChangeRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        userService.changeCurrentPassword(userDetails.getUsername(), request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/lassriver/bookworm/dtos/request/PasswordChangeRequest.java
+++ b/src/main/java/com/lassriver/bookworm/dtos/request/PasswordChangeRequest.java
@@ -1,0 +1,16 @@
+package com.lassriver.bookworm.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PasswordChangeRequest {
+
+    @NotBlank(message = "La contrasena actual es obligatoria")
+    private String currentPassword;
+
+    @NotBlank(message = "La nueva contrasena es obligatoria")
+    @Size(min = 8, message = "La nueva contrasena debe tener al menos 8 caracteres")
+    private String newPassword;
+}

--- a/src/main/java/com/lassriver/bookworm/services/BookService.java
+++ b/src/main/java/com/lassriver/bookworm/services/BookService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BookService {
-    Page<BookResponse> getBooks(String title, String category, Pageable pageable);
+    Page<BookResponse> getBooks(String search, String title, String category, String language, String status, Pageable pageable);
 
     BookResponse getBook(Long id);
 
@@ -14,5 +14,5 @@ public interface BookService {
 
     BookResponse updateBook(Long id, BookUpsertRequest request);
 
-    BookResponse deactivateBook(Long id);
+    BookResponse updateBookStatus(Long id, String status);
 }

--- a/src/main/java/com/lassriver/bookworm/services/UserService.java
+++ b/src/main/java/com/lassriver/bookworm/services/UserService.java
@@ -1,6 +1,7 @@
 package com.lassriver.bookworm.services;
 
 import com.lassriver.bookworm.dtos.request.LoginRequest;
+import com.lassriver.bookworm.dtos.request.PasswordChangeRequest;
 import com.lassriver.bookworm.dtos.request.UserProfileUpdateRequest;
 import com.lassriver.bookworm.dtos.request.UserRegistrationRequest;
 import com.lassriver.bookworm.dtos.response.LoginResponse;
@@ -15,4 +16,6 @@ public interface UserService {
     UserProfileResponse getCurrentProfile(String authenticatedEmail);
 
     UserProfileResponse updateCurrentProfile(String authenticatedEmail, UserProfileUpdateRequest request);
+
+    void changeCurrentPassword(String authenticatedEmail, PasswordChangeRequest request);
 }

--- a/src/main/java/com/lassriver/bookworm/services/impl/BookServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/BookServiceImpl.java
@@ -3,6 +3,7 @@ package com.lassriver.bookworm.services.impl;
 import com.lassriver.bookworm.dtos.request.BookUpsertRequest;
 import com.lassriver.bookworm.dtos.response.BookResponse;
 import com.lassriver.bookworm.entities.Book;
+import com.lassriver.bookworm.exceptions.BusinessRuleException;
 import com.lassriver.bookworm.exceptions.ResourceNotFoundException;
 import com.lassriver.bookworm.repositories.BookRepository;
 import com.lassriver.bookworm.repositories.ReviewRepository;
@@ -27,9 +28,17 @@ public class BookServiceImpl implements BookService {
     private static final String REVIEW_VISIBLE = "VISIBLE";
 
     @Override
-    public Page<BookResponse> getBooks(String title, String category, Pageable pageable) {
+    public Page<BookResponse> getBooks(String search, String title, String category, String language, String status, Pageable pageable) {
         Specification<Book> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
+
+            if (search != null && !search.isBlank()) {
+                String term = "%" + search.toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("title")), term),
+                        cb.like(cb.lower(root.get("author")), term),
+                        cb.like(cb.lower(root.get("isbn")), term)));
+            }
 
             if (title != null && !title.isBlank()) {
                 predicates.add(cb.like(cb.lower(root.get("title")), "%" + title.toLowerCase() + "%"));
@@ -37,6 +46,14 @@ public class BookServiceImpl implements BookService {
 
             if (category != null && !category.isBlank()) {
                 predicates.add(cb.like(cb.lower(root.get("category")), "%" + category.toLowerCase() + "%"));
+            }
+
+            if (language != null && !language.isBlank()) {
+                predicates.add(cb.equal(cb.lower(root.get("language")), language.toLowerCase()));
+            }
+
+            if (status != null && !status.isBlank()) {
+                predicates.add(cb.equal(cb.upper(root.get("status")), normalizeStatus(status)));
             }
 
             return cb.and(predicates.toArray(new Predicate[0]));
@@ -73,14 +90,22 @@ public class BookServiceImpl implements BookService {
     }
 
     @Override
-    public BookResponse deactivateBook(Long id) {
+    public BookResponse updateBookStatus(Long id, String status) {
         Book book = bookRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Libro no encontrado con id: " + id));
 
-        book.setStatus("INACTIVE");
+        book.setStatus(normalizeStatus(status));
 
         Book updatedBook = bookRepository.save(book);
         return toResponse(updatedBook);
+    }
+
+    private String normalizeStatus(String status) {
+        String normalized = status == null || status.isBlank() ? "INACTIVE" : status.trim().toUpperCase();
+        if (!"ACTIVE".equals(normalized) && !"INACTIVE".equals(normalized)) {
+            throw new BusinessRuleException("Estado de libro invalido: " + status);
+        }
+        return normalized;
     }
 
     private void mapRequestToEntity(BookUpsertRequest request, Book book) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.lassriver.bookworm.services.impl;
 
 import com.lassriver.bookworm.dtos.request.LoginRequest;
+import com.lassriver.bookworm.dtos.request.PasswordChangeRequest;
 import com.lassriver.bookworm.dtos.request.UserProfileUpdateRequest;
 import com.lassriver.bookworm.dtos.request.UserRegistrationRequest;
 import com.lassriver.bookworm.dtos.response.LoginResponse;
@@ -101,6 +102,20 @@ public class UserServiceImpl implements UserService {
 
         user.setName(request.getName());
         return toProfileResponse(userRepository.save(user));
+    }
+
+    @Override
+    @Transactional
+    public void changeCurrentPassword(String authenticatedEmail, PasswordChangeRequest request) {
+        User user = getUserByEmail(authenticatedEmail);
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new BusinessRuleException("La contrasena actual no es correcta.");
+        }
+        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+            throw new BusinessRuleException("La nueva contrasena debe ser diferente a la actual.");
+        }
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
     }
 
     private User getUserByEmail(String email) {

--- a/src/test/java/com/lassriver/bookworm/services/impl/BookServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/BookServiceImplTest.java
@@ -43,7 +43,7 @@ class BookServiceImplTest {
 
         when(bookRepository.findAll(any(Specification.class), any(PageRequest.class))).thenReturn(page);
 
-        Page<BookResponse> response = bookService.getBooks("clean", "software", PageRequest.of(0, 10));
+        Page<BookResponse> response = bookService.getBooks("clean", null, "software", null, null, PageRequest.of(0, 10));
 
         assertNotNull(response);
         assertEquals(1, response.getTotalElements());
@@ -85,14 +85,14 @@ class BookServiceImplTest {
     }
 
     @Test
-    void deactivateBook_HappyPath_ChangesStatusToInactive() {
+    void updateBookStatus_HappyPath_ChangesStatusToInactive() {
         Book book = Book.builder().id(5L).title("Book").status("ACTIVE").build();
         Book updated = Book.builder().id(5L).title("Book").status("INACTIVE").build();
 
         when(bookRepository.findById(5L)).thenReturn(Optional.of(book));
         when(bookRepository.save(eq(book))).thenReturn(updated);
 
-        BookResponse response = bookService.deactivateBook(5L);
+        BookResponse response = bookService.updateBookStatus(5L, "INACTIVE");
 
         assertEquals("INACTIVE", response.getStatus());
         verify(bookRepository, times(1)).save(book);

--- a/src/test/java/com/lassriver/bookworm/services/impl/UserServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/UserServiceImplTest.java
@@ -1,10 +1,12 @@
 package com.lassriver.bookworm.services.impl;
 
 import com.lassriver.bookworm.dtos.request.LoginRequest;
+import com.lassriver.bookworm.dtos.request.PasswordChangeRequest;
 import com.lassriver.bookworm.dtos.request.UserRegistrationRequest;
 import com.lassriver.bookworm.dtos.response.LoginResponse;
 import com.lassriver.bookworm.dtos.response.UserRegistrationResponse;
 import com.lassriver.bookworm.entities.User;
+import com.lassriver.bookworm.exceptions.BusinessRuleException;
 import com.lassriver.bookworm.exceptions.EmailAlreadyExistsException;
 import com.lassriver.bookworm.repositories.UserRepository;
 import com.lassriver.bookworm.security.JwtService;
@@ -113,5 +115,44 @@ class UserServiceImplTest {
 
         assertThrows(org.springframework.security.authentication.BadCredentialsException.class,
                 () -> userService.login(request));
+    }
+
+    @Test
+    void changeCurrentPassword_HappyPath_UpdatesPassword() {
+        User user = new User();
+        user.setEmail("kevin@test.com");
+        user.setPassword("encoded-current");
+
+        PasswordChangeRequest request = new PasswordChangeRequest();
+        request.setCurrentPassword("Password123!");
+        request.setNewPassword("NewPassword123!");
+
+        when(userRepository.findByEmail("kevin@test.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("Password123!", "encoded-current")).thenReturn(true);
+        when(passwordEncoder.matches("NewPassword123!", "encoded-current")).thenReturn(false);
+        when(passwordEncoder.encode("NewPassword123!")).thenReturn("encoded-new");
+
+        userService.changeCurrentPassword("kevin@test.com", request);
+
+        assertEquals("encoded-new", user.getPassword());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void changeCurrentPassword_WhenCurrentPasswordIsWrong_ThrowsBusinessRuleException() {
+        User user = new User();
+        user.setEmail("kevin@test.com");
+        user.setPassword("encoded-current");
+
+        PasswordChangeRequest request = new PasswordChangeRequest();
+        request.setCurrentPassword("wrong");
+        request.setNewPassword("NewPassword123!");
+
+        when(userRepository.findByEmail("kevin@test.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "encoded-current")).thenReturn(false);
+
+        assertThrows(BusinessRuleException.class,
+                () -> userService.changeCurrentPassword("kevin@test.com", request));
+        verify(userRepository, never()).save(any(User.class));
     }
 }


### PR DESCRIPTION
## Description
Adds the backend API support required for the next hardening phase: server-side book filtering/status updates and authenticated password changes.

## Changes Made
- Extended GET /api/books with search, language, status, and existing category/title filters
- Updated PATCH /api/books/{id}/status to support ACTIVE and INACTIVE
- Added PATCH /api/users/me/password for authenticated password changes
- Added validation DTO for password changes
- Updated unit tests for book status updates and password change flows

## Testing
- [x] Unit tests pass with .\\mvnw.cmd test
- [x] 26 tests passed, 0 failures, 0 errors