### PR TITLE
feat: Add transactional notifications

### DIFF
--- a/src/main/java/com/lassriver/bookworm/BookwormApplication.java
+++ b/src/main/java/com/lassriver/bookworm/BookwormApplication.java
@@ -2,8 +2,10 @@ package com.lassriver.bookworm;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BookwormApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/lassriver/bookworm/config/SecurityConfig.java
+++ b/src/main/java/com/lassriver/bookworm/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/books/*/status").hasAnyAuthority("ADMIN", "LIBRARIAN")
                         .requestMatchers(HttpMethod.GET, "/api/books/*/copies").hasAnyAuthority("ADMIN", "LIBRARIAN")
                         .requestMatchers(HttpMethod.POST, "/api/books/*/copies").hasAnyAuthority("ADMIN", "LIBRARIAN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/books/*/copies/*").hasAnyAuthority("ADMIN", "LIBRARIAN")
                         .requestMatchers(HttpMethod.POST, "/api/books/*/pdf/upload", "/api/books/*/pdf/download").hasAnyAuthority("ADMIN", "LIBRARIAN")
                         .requestMatchers(HttpMethod.GET, "/api/loans").hasAnyAuthority("ADMIN", "LIBRARIAN")
                         .requestMatchers(HttpMethod.GET, "/api/reviews").hasAnyAuthority("ADMIN", "LIBRARIAN")

--- a/src/main/java/com/lassriver/bookworm/controllers/BookController.java
+++ b/src/main/java/com/lassriver/bookworm/controllers/BookController.java
@@ -78,6 +78,11 @@ public class BookController {
         return new ResponseEntity<>(bookCopyService.createCopy(id), HttpStatus.CREATED);
     }
 
+    @DeleteMapping("/{id}/copies/{copyId}")
+    public ResponseEntity<BookCopyResponse> retireCopy(@PathVariable Long id, @PathVariable Long copyId) {
+        return ResponseEntity.ok(bookCopyService.retireCopy(id, copyId));
+    }
+
     @PostMapping
     public ResponseEntity<BookResponse> createBook(@Valid @RequestBody BookUpsertRequest request) {
         BookResponse response = bookService.createBook(request);

--- a/src/main/java/com/lassriver/bookworm/controllers/NotificationController.java
+++ b/src/main/java/com/lassriver/bookworm/controllers/NotificationController.java
@@ -1,0 +1,52 @@
+package com.lassriver.bookworm.controllers;
+
+import com.lassriver.bookworm.dtos.response.NotificationResponse;
+import com.lassriver.bookworm.dtos.response.PageResponse;
+import com.lassriver.bookworm.dtos.response.UnreadNotificationsResponse;
+import com.lassriver.bookworm.services.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<NotificationResponse>> getMyNotifications(
+            @RequestParam(defaultValue = "all") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(1, Math.min(size, MAX_PAGE_SIZE)));
+        return ResponseEntity.ok(notificationService.getMyNotifications(userDetails.getUsername(), status, pageable));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<UnreadNotificationsResponse> getUnreadCount(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(notificationService.getUnreadCount(userDetails.getUsername()));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<NotificationResponse> markAsRead(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(notificationService.markAsRead(id, userDetails.getUsername()));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<UnreadNotificationsResponse> markAllAsRead(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(notificationService.markAllAsRead(userDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/lassriver/bookworm/dtos/request/ChatRequest.java
+++ b/src/main/java/com/lassriver/bookworm/dtos/request/ChatRequest.java
@@ -23,6 +23,9 @@ public class ChatRequest {
     @Size(max = 2000, message = "La pregunta no puede superar 2000 caracteres")
     private String question;
 
+    @Size(max = 300, message = "La clave del proveedor IA no puede superar 300 caracteres")
+    private String providerApiKey;
+
     @Valid
     private List<ChatMessageRequest> history = new ArrayList<>();
 }

--- a/src/main/java/com/lassriver/bookworm/dtos/response/BookResponse.java
+++ b/src/main/java/com/lassriver/bookworm/dtos/response/BookResponse.java
@@ -26,6 +26,7 @@ public class BookResponse {
     private Boolean hasPdf;
     private String pdfUrl;
     private Boolean reservedByMe;
+    private LocalDateTime loanCooldownUntil;
     private Long totalCopies;
     private Long availableCopies;
     private Long waitingReservations;

--- a/src/main/java/com/lassriver/bookworm/dtos/response/NotificationResponse.java
+++ b/src/main/java/com/lassriver/bookworm/dtos/response/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.lassriver.bookworm.dtos.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class NotificationResponse {
+    private Long id;
+    private String type;
+    private String title;
+    private String message;
+    private String targetView;
+    private Long targetId;
+    private LocalDateTime readAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/lassriver/bookworm/dtos/response/UnreadNotificationsResponse.java
+++ b/src/main/java/com/lassriver/bookworm/dtos/response/UnreadNotificationsResponse.java
@@ -1,0 +1,10 @@
+package com.lassriver.bookworm.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UnreadNotificationsResponse {
+    private long unreadCount;
+}

--- a/src/main/java/com/lassriver/bookworm/entities/Notification.java
+++ b/src/main/java/com/lassriver/bookworm/entities/Notification.java
@@ -1,0 +1,60 @@
+package com.lassriver.bookworm.entities;
+
+import com.lassriver.bookworm.entities.enums.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications", indexes = {
+        @Index(name = "idx_notifications_user_read", columnList = "user_id, read_at"),
+        @Index(name = "idx_notifications_user_created", columnList = "user_id, created_at")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 120)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "target_view", length = 40)
+    private String targetView;
+
+    @Column(name = "target_id")
+    private Long targetId;
+
+    @Column(name = "dedupe_key", length = 160)
+    private String dedupeKey;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/lassriver/bookworm/entities/enums/NotificationType.java
+++ b/src/main/java/com/lassriver/bookworm/entities/enums/NotificationType.java
@@ -1,0 +1,12 @@
+package com.lassriver.bookworm.entities.enums;
+
+public enum NotificationType {
+    LOAN_CREATED,
+    LOAN_RENEWED,
+    LOAN_RETURNED,
+    LOAN_DUE_SOON,
+    LOAN_OVERDUE,
+    RESERVATION_CREATED,
+    RESERVATION_CANCELLED,
+    RESERVATION_FULFILLED
+}

--- a/src/main/java/com/lassriver/bookworm/repositories/BookCopyRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/BookCopyRepository.java
@@ -7,16 +7,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BookCopyRepository extends JpaRepository<BookCopy, Long> {
 
     long countByBookId(Long bookId);
 
+    long countByBookIdAndStatusIn(Long bookId, Collection<BookCopyStatus> statuses);
+
     long countByBookIdAndStatus(Long bookId, BookCopyStatus status);
 
     List<BookCopy> findAllByBookIdOrderByIdAsc(Long bookId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<BookCopy> findByIdAndBookId(Long id, Long bookId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<BookCopy> findAllByBookIdAndStatusOrderByIdAsc(Long bookId, BookCopyStatus status);

--- a/src/main/java/com/lassriver/bookworm/repositories/LoanRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/LoanRepository.java
@@ -25,6 +25,15 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
 
     List<Loan> findAllByUserIdOrderByLoanDateDesc(Long userId);
 
+    List<Loan> findAllByStatusInAndDueDateBetween(
+            Collection<LoanStatus> statuses,
+            java.time.LocalDateTime start,
+            java.time.LocalDateTime end);
+
+    List<Loan> findAllByStatusInAndDueDateBefore(
+            Collection<LoanStatus> statuses,
+            java.time.LocalDateTime dateTime);
+
     boolean existsByUserIdAndBookId(Long userId, Long bookId);
 
     boolean existsByUserIdAndBookIdAndStatus(Long userId, Long bookId, LoanStatus status);

--- a/src/main/java/com/lassriver/bookworm/repositories/LoanRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/LoanRepository.java
@@ -25,6 +25,12 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
 
     List<Loan> findAllByUserIdOrderByLoanDateDesc(Long userId);
 
+    Optional<Loan> findFirstByUserIdAndBookIdAndStatusAndReturnedAtAfterOrderByReturnedAtDesc(
+            Long userId,
+            Long bookId,
+            LoanStatus status,
+            java.time.LocalDateTime returnedAt);
+
     List<Loan> findAllByStatusInAndDueDateBetween(
             Collection<LoanStatus> statuses,
             java.time.LocalDateTime start,

--- a/src/main/java/com/lassriver/bookworm/repositories/NotificationRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/NotificationRepository.java
@@ -1,0 +1,36 @@
+package com.lassriver.bookworm.repositories;
+
+import com.lassriver.bookworm.entities.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<Notification> findAllByUserIdAndReadAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    long countByUserIdAndReadAtIsNull(Long userId);
+
+    boolean existsByDedupeKey(String dedupeKey);
+
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
+
+    @Modifying
+    @Query("""
+            update Notification n
+            set n.readAt = :readAt
+            where n.user.id = :userId
+              and n.readAt is null
+            """)
+    int markAllUnreadAsRead(@Param("userId") Long userId, @Param("readAt") LocalDateTime readAt);
+}

--- a/src/main/java/com/lassriver/bookworm/repositories/ReviewRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/ReviewRepository.java
@@ -20,4 +20,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByBookIdAndStatusOrderByCreatedAtDesc(Long bookId, String status);
 
     List<Review> findAllByStatusOrderByCreatedAtDesc(String status);
+
+    List<Review> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/lassriver/bookworm/repositories/UserRepository.java
+++ b/src/main/java/com/lassriver/bookworm/repositories/UserRepository.java
@@ -1,10 +1,14 @@
 package com.lassriver.bookworm.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.lassriver.bookworm.entities.User;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    @Query("select u from User u where upper(u.role) in :roles")
+    List<User> findAllByRoleUpperIn(@Param("roles") Collection<String> roles);
 }

--- a/src/main/java/com/lassriver/bookworm/services/BookCopyService.java
+++ b/src/main/java/com/lassriver/bookworm/services/BookCopyService.java
@@ -10,5 +10,7 @@ public interface BookCopyService {
 
     BookCopyResponse createCopy(Long bookId);
 
+    BookCopyResponse retireCopy(Long bookId, Long copyId);
+
     List<BookCopyResponse> getCopies(Long bookId);
 }

--- a/src/main/java/com/lassriver/bookworm/services/NotificationService.java
+++ b/src/main/java/com/lassriver/bookworm/services/NotificationService.java
@@ -1,0 +1,34 @@
+package com.lassriver.bookworm.services;
+
+import com.lassriver.bookworm.dtos.response.NotificationResponse;
+import com.lassriver.bookworm.dtos.response.PageResponse;
+import com.lassriver.bookworm.dtos.response.UnreadNotificationsResponse;
+import com.lassriver.bookworm.entities.Loan;
+import com.lassriver.bookworm.entities.Reservation;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationService {
+    PageResponse<NotificationResponse> getMyNotifications(String authenticatedEmail, String status, Pageable pageable);
+
+    UnreadNotificationsResponse getUnreadCount(String authenticatedEmail);
+
+    NotificationResponse markAsRead(Long notificationId, String authenticatedEmail);
+
+    UnreadNotificationsResponse markAllAsRead(String authenticatedEmail);
+
+    void notifyLoanCreated(Loan loan);
+
+    void notifyLoanRenewed(Loan loan);
+
+    void notifyLoanReturned(Loan loan);
+
+    void notifyLoanDueSoon(Loan loan);
+
+    void notifyLoanOverdue(Loan loan);
+
+    void notifyReservationCreated(Reservation reservation);
+
+    void notifyReservationCancelled(Reservation reservation);
+
+    void notifyReservationFulfilled(Reservation reservation);
+}

--- a/src/main/java/com/lassriver/bookworm/services/ai/AiChatClient.java
+++ b/src/main/java/com/lassriver/bookworm/services/ai/AiChatClient.java
@@ -4,5 +4,5 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public interface AiChatClient {
-    void stream(List<AiMessage> messages, Consumer<String> onChunk);
+    void stream(List<AiMessage> messages, String providerApiKey, Consumer<String> onChunk);
 }

--- a/src/main/java/com/lassriver/bookworm/services/ai/OpenAiCompatibleChatClient.java
+++ b/src/main/java/com/lassriver/bookworm/services/ai/OpenAiCompatibleChatClient.java
@@ -34,19 +34,37 @@ public class OpenAiCompatibleChatClient implements AiChatClient {
     private String model;
 
     @Override
-    public void stream(List<AiMessage> messages, Consumer<String> onChunk) {
-        if (apiKey == null || apiKey.isBlank()) {
-            onChunk.accept("El asistente IA no esta configurado. Define DEEPSEEK_API_KEY o bookworm.ai.api-key.");
+    public void stream(List<AiMessage> messages, String providerApiKey, Consumer<String> onChunk) {
+        String systemApiKey = blankToNull(apiKey);
+        String personalApiKey = blankToNull(providerApiKey);
+        if (systemApiKey == null && personalApiKey == null) {
+            throw new BusinessRuleException("El asistente IA no esta configurado. Agrega una clave personal de DeepSeek.");
+        }
+
+        if (systemApiKey == null) {
+            streamWithKey(messages, personalApiKey, onChunk);
             return;
         }
 
+        try {
+            streamWithKey(messages, systemApiKey, onChunk);
+        } catch (BusinessRuleException ex) {
+            if (personalApiKey != null && !personalApiKey.equals(systemApiKey)) {
+                streamWithKey(messages, personalApiKey, onChunk);
+                return;
+            }
+            throw ex;
+        }
+    }
+
+    private void streamWithKey(List<AiMessage> messages, String effectiveApiKey, Consumer<String> onChunk) {
         try {
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(Duration.ofSeconds(15))
                     .build();
             HttpRequest request = HttpRequest.newBuilder(chatCompletionsUri())
                     .timeout(Duration.ofSeconds(90))
-                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Authorization", "Bearer " + effectiveApiKey)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(buildBody(messages))))
                     .build();
@@ -77,6 +95,10 @@ public class OpenAiCompatibleChatClient implements AiChatClient {
         } catch (Exception ex) {
             throw new BusinessRuleException("No se pudo contactar el proveedor IA.");
         }
+    }
+
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private URI chatCompletionsUri() {

--- a/src/main/java/com/lassriver/bookworm/services/impl/BookCopyServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/BookCopyServiceImpl.java
@@ -22,6 +22,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BookCopyServiceImpl implements BookCopyService {
 
+    private static final List<BookCopyStatus> COUNTED_COPY_STATUSES = List.of(
+            BookCopyStatus.AVAILABLE,
+            BookCopyStatus.LOANED,
+            BookCopyStatus.RESERVED);
+
     private final BookRepository bookRepository;
     private final BookCopyRepository bookCopyRepository;
     private final ReservationRepository reservationRepository;
@@ -55,6 +60,31 @@ public class BookCopyServiceImpl implements BookCopyService {
     }
 
     @Override
+    @Transactional
+    public BookCopyResponse retireCopy(Long bookId, Long copyId) {
+        bookRepository.findLockedById(bookId)
+                .orElseThrow(() -> new ResourceNotFoundException("Libro no encontrado con id: " + bookId));
+
+        BookCopy copy = bookCopyRepository.findByIdAndBookId(copyId, bookId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ejemplar no encontrado con id: " + copyId));
+
+        if (reservationRepository.existsByBookIdAndStatus(bookId, ReservationStatus.WAITING)) {
+            throw new BusinessRuleException("No se pueden retirar ejemplares mientras existan reservas en cola.");
+        }
+
+        if (!BookCopyStatus.AVAILABLE.equals(copy.getStatus())) {
+            throw new BusinessRuleException("Solo se pueden retirar ejemplares disponibles.");
+        }
+
+        if (bookCopyRepository.countByBookIdAndStatusIn(bookId, COUNTED_COPY_STATUSES) <= 1) {
+            throw new BusinessRuleException("No se puede retirar el ultimo ejemplar del libro.");
+        }
+
+        copy.setStatus(BookCopyStatus.INACTIVE);
+        return toResponse(bookCopyRepository.save(copy));
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public List<BookCopyResponse> getCopies(Long bookId) {
         if (!bookRepository.existsById(bookId)) {
@@ -69,7 +99,7 @@ public class BookCopyServiceImpl implements BookCopyService {
     private BookAvailabilityResponse availabilityFor(Long bookId) {
         return BookAvailabilityResponse.builder()
                 .bookId(bookId)
-                .totalCopies(bookCopyRepository.countByBookId(bookId))
+                .totalCopies(bookCopyRepository.countByBookIdAndStatusIn(bookId, COUNTED_COPY_STATUSES))
                 .availableCopies(bookCopyRepository.countByBookIdAndStatus(bookId, BookCopyStatus.AVAILABLE))
                 .loanedCopies(bookCopyRepository.countByBookIdAndStatus(bookId, BookCopyStatus.LOANED))
                 .reservedCopies(bookCopyRepository.countByBookIdAndStatus(bookId, BookCopyStatus.RESERVED))

--- a/src/main/java/com/lassriver/bookworm/services/impl/BookServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/BookServiceImpl.java
@@ -5,6 +5,7 @@ import com.lassriver.bookworm.dtos.response.BookFacetsResponse;
 import com.lassriver.bookworm.dtos.response.BookResponse;
 import com.lassriver.bookworm.entities.Book;
 import com.lassriver.bookworm.entities.BookCopy;
+import com.lassriver.bookworm.entities.Loan;
 import com.lassriver.bookworm.entities.enums.BookCopyStatus;
 import com.lassriver.bookworm.entities.enums.LoanStatus;
 import com.lassriver.bookworm.entities.enums.ReservationStatus;
@@ -27,6 +28,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,6 +44,11 @@ public class BookServiceImpl implements BookService {
     private final ReservationRepository reservationRepository;
 
     private static final String REVIEW_VISIBLE = "VISIBLE";
+    private static final int LOAN_COOLDOWN_HOURS = 24;
+    private static final List<BookCopyStatus> COUNTED_COPY_STATUSES = List.of(
+            BookCopyStatus.AVAILABLE,
+            BookCopyStatus.LOANED,
+            BookCopyStatus.RESERVED);
 
     @Override
     @Transactional(readOnly = true)
@@ -169,12 +176,14 @@ public class BookServiceImpl implements BookService {
     }
 
     private void ensureInitialCopy(Book book) {
-        if (!"ACTIVE".equalsIgnoreCase(book.getStatus()) || bookCopyRepository.countByBookId(book.getId()) > 0) {
+        if (!"ACTIVE".equalsIgnoreCase(book.getStatus())
+                || bookCopyRepository.countByBookIdAndStatusIn(book.getId(), COUNTED_COPY_STATUSES) > 0) {
             return;
         }
+        long nextCopyNumber = bookCopyRepository.countByBookId(book.getId()) + 1;
         bookCopyRepository.save(BookCopy.builder()
                 .book(book)
-                .copyCode("BOOK-" + book.getId() + "-COPY-1")
+                .copyCode("BOOK-" + book.getId() + "-COPY-" + nextCopyNumber)
                 .status(BookCopyStatus.AVAILABLE)
                 .build());
     }
@@ -210,7 +219,8 @@ public class BookServiceImpl implements BookService {
         boolean hasPdf = book.getPdfPath() != null && !book.getPdfPath().isBlank();
         boolean reservedByMe = userId != null
                 && loanRepository.existsByUserIdAndBookIdAndStatus(userId, book.getId(), LoanStatus.ACTIVE);
-        long totalCopies = bookCopyRepository.countByBookId(book.getId());
+        LocalDateTime loanCooldownUntil = getLoanCooldownUntil(userId, book.getId());
+        long totalCopies = bookCopyRepository.countByBookIdAndStatusIn(book.getId(), COUNTED_COPY_STATUSES);
         long availableCopies = bookCopyRepository.countByBookIdAndStatus(book.getId(), BookCopyStatus.AVAILABLE);
         long waitingReservations = reservationRepository.countByBookIdAndStatus(book.getId(), ReservationStatus.WAITING);
 
@@ -232,11 +242,28 @@ public class BookServiceImpl implements BookService {
                 .hasPdf(hasPdf)
                 .pdfUrl(hasPdf ? "/api/books/" + book.getId() + "/pdf" : null)
                 .reservedByMe(reservedByMe)
+                .loanCooldownUntil(loanCooldownUntil)
                 .totalCopies(totalCopies)
                 .availableCopies(availableCopies)
                 .waitingReservations(waitingReservations)
                 .createdAt(book.getCreatedAt())
                 .build();
+    }
+
+    private LocalDateTime getLoanCooldownUntil(Long userId, Long bookId) {
+        if (userId == null) {
+            return null;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        return loanRepository.findFirstByUserIdAndBookIdAndStatusAndReturnedAtAfterOrderByReturnedAtDesc(
+                        userId,
+                        bookId,
+                        LoanStatus.RETURNED,
+                        now.minusHours(LOAN_COOLDOWN_HOURS))
+                .map(Loan::getReturnedAt)
+                .map(returnedAt -> returnedAt.plusHours(LOAN_COOLDOWN_HOURS))
+                .filter(cooldownUntil -> cooldownUntil.isAfter(now))
+                .orElse(null);
     }
 
     private Long resolveUserId(String authenticatedEmail) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/ChatServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/ChatServiceImpl.java
@@ -43,7 +43,7 @@ public class ChatServiceImpl implements ChatService {
 
         Thread.ofVirtual().start(() -> {
             try {
-                aiChatClient.stream(messages, chunk -> sendChunk(emitter, chunk));
+                aiChatClient.stream(messages, request.getProviderApiKey(), chunk -> sendChunk(emitter, chunk));
                 emitter.send(SseEmitter.event().data("[DONE]"));
                 emitter.complete();
             } catch (Exception ex) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/LoanServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/LoanServiceImpl.java
@@ -38,6 +38,7 @@ public class LoanServiceImpl implements LoanService {
 
     private static final int MIN_LOAN_DURATION_MINUTES = 5;
     private static final int MAX_LOAN_DURATION_MINUTES = 10_080;
+    private static final int LOAN_COOLDOWN_HOURS = 24;
     private static final int MAX_ACTIVE_LOANS_PER_USER = 3;
     private static final int MAX_RENEWALS_PER_LOAN = 2;
     private static final List<LoanStatus> OPEN_LOAN_STATUSES = List.of(LoanStatus.ACTIVE, LoanStatus.OVERDUE);
@@ -213,10 +214,23 @@ public class LoanServiceImpl implements LoanService {
             throw new BusinessRuleException("Ya tienes un prestamo activo para este libro.");
         }
 
+        if (isLoanCooldownActive(user, book)) {
+            throw new BusinessRuleException("Debes esperar 24 horas despues de devolver este libro para volver a reservarlo.");
+        }
+
         long openLoans = loanRepository.countByUserIdAndStatusIn(user.getId(), OPEN_LOAN_STATUSES);
         if (openLoans >= MAX_ACTIVE_LOANS_PER_USER) {
             throw new BusinessRuleException("Has alcanzado el limite de prestamos activos.");
         }
+    }
+
+    private boolean isLoanCooldownActive(User user, Book book) {
+        LocalDateTime returnedAfter = LocalDateTime.now().minusHours(LOAN_COOLDOWN_HOURS);
+        return loanRepository.findFirstByUserIdAndBookIdAndStatusAndReturnedAtAfterOrderByReturnedAtDesc(
+                user.getId(),
+                book.getId(),
+                LoanStatus.RETURNED,
+                returnedAfter).isPresent();
     }
 
     private BookCopy getAvailableCopy(Book book) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/LoanServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/LoanServiceImpl.java
@@ -22,6 +22,7 @@ import com.lassriver.bookworm.repositories.LoanRepository;
 import com.lassriver.bookworm.repositories.ReservationRepository;
 import com.lassriver.bookworm.repositories.UserRepository;
 import com.lassriver.bookworm.services.LoanService;
+import com.lassriver.bookworm.services.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,7 @@ public class LoanServiceImpl implements LoanService {
     private final BookCopyRepository bookCopyRepository;
     private final ReservationRepository reservationRepository;
     private final LoanRenewalRepository loanRenewalRepository;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -71,7 +73,9 @@ public class LoanServiceImpl implements LoanService {
                 .renewalCount(0)
                 .build();
 
-        return toResponse(loanRepository.save(loan));
+        Loan savedLoan = loanRepository.save(loan);
+        notificationService.notifyLoanCreated(savedLoan);
+        return toResponse(savedLoan);
     }
 
     @Override
@@ -96,7 +100,9 @@ public class LoanServiceImpl implements LoanService {
         if (returnedCopy != null) {
             returnedCopy.setStatus(BookCopyStatus.AVAILABLE);
         }
-        LoanResponse response = toResponse(loanRepository.save(loan));
+        Loan savedLoan = loanRepository.save(loan);
+        notificationService.notifyLoanReturned(savedLoan);
+        LoanResponse response = toResponse(savedLoan);
 
         if (returnedCopy != null && "ACTIVE".equalsIgnoreCase(loan.getBook().getStatus())) {
             fulfillNextReservation(loan.getBook(), returnedCopy);
@@ -136,7 +142,9 @@ public class LoanServiceImpl implements LoanService {
                 .build();
         loanRenewalRepository.save(renewal);
 
-        return toResponse(loanRepository.save(loan));
+        Loan savedLoan = loanRepository.save(loan);
+        notificationService.notifyLoanRenewed(savedLoan);
+        return toResponse(savedLoan);
     }
 
     @Override
@@ -253,7 +261,8 @@ public class LoanServiceImpl implements LoanService {
         reservation.setStatus(ReservationStatus.FULFILLED);
         reservation.setFulfilledAt(now);
         reservation.setFulfilledLoan(savedLoan);
-        reservationRepository.save(reservation);
+        Reservation fulfilledReservation = reservationRepository.save(reservation);
+        notificationService.notifyReservationFulfilled(fulfilledReservation);
     }
 
     private String getRenewalBlockedReason(Loan loan) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/NotificationDueDateScheduler.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/NotificationDueDateScheduler.java
@@ -1,0 +1,42 @@
+package com.lassriver.bookworm.services.impl;
+
+import com.lassriver.bookworm.entities.Loan;
+import com.lassriver.bookworm.entities.enums.LoanStatus;
+import com.lassriver.bookworm.repositories.LoanRepository;
+import com.lassriver.bookworm.services.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationDueDateScheduler {
+
+    private static final List<LoanStatus> OPEN_STATUSES = List.of(LoanStatus.ACTIVE, LoanStatus.OVERDUE);
+
+    private final LoanRepository loanRepository;
+    private final NotificationService notificationService;
+
+    @Scheduled(
+            initialDelayString = "${bookworm.notifications.due-scan-initial-delay-ms:60000}",
+            fixedDelayString = "${bookworm.notifications.due-scan-interval-ms:60000}")
+    @Transactional
+    public void notifyDueLoans() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime dueSoonLimit = now.plusHours(24);
+
+        loanRepository.findAllByStatusInAndDueDateBetween(OPEN_STATUSES, now, dueSoonLimit)
+                .forEach(notificationService::notifyLoanDueSoon);
+
+        for (Loan loan : loanRepository.findAllByStatusInAndDueDateBefore(OPEN_STATUSES, now)) {
+            if (LoanStatus.ACTIVE.equals(loan.getStatus())) {
+                loan.setStatus(LoanStatus.OVERDUE);
+            }
+            notificationService.notifyLoanOverdue(loan);
+        }
+    }
+}

--- a/src/main/java/com/lassriver/bookworm/services/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/NotificationServiceImpl.java
@@ -1,0 +1,344 @@
+package com.lassriver.bookworm.services.impl;
+
+import com.lassriver.bookworm.dtos.response.NotificationResponse;
+import com.lassriver.bookworm.dtos.response.PageResponse;
+import com.lassriver.bookworm.dtos.response.UnreadNotificationsResponse;
+import com.lassriver.bookworm.entities.Loan;
+import com.lassriver.bookworm.entities.Notification;
+import com.lassriver.bookworm.entities.Reservation;
+import com.lassriver.bookworm.entities.User;
+import com.lassriver.bookworm.entities.enums.NotificationType;
+import com.lassriver.bookworm.exceptions.BusinessRuleException;
+import com.lassriver.bookworm.exceptions.ResourceNotFoundException;
+import com.lassriver.bookworm.repositories.NotificationRepository;
+import com.lassriver.bookworm.repositories.UserRepository;
+import com.lassriver.bookworm.services.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private static final String TARGET_LOANS = "loans";
+    private static final String TARGET_RESERVATIONS = "reservations";
+    private static final List<String> STAFF_ROLES = List.of("ADMIN", "LIBRARIAN");
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<NotificationResponse> getMyNotifications(
+            String authenticatedEmail,
+            String status,
+            Pageable pageable) {
+        User user = getUserByEmail(authenticatedEmail);
+        String normalizedStatus = status == null ? "all" : status.trim().toLowerCase();
+
+        Page<Notification> page = switch (normalizedStatus) {
+            case "all" -> notificationRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId(), pageable);
+            case "unread" -> notificationRepository.findAllByUserIdAndReadAtIsNullOrderByCreatedAtDesc(
+                    user.getId(), pageable);
+            default -> throw new BusinessRuleException("El filtro de notificaciones debe ser all o unread.");
+        };
+
+        return PageResponse.from(page.map(this::toResponse));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UnreadNotificationsResponse getUnreadCount(String authenticatedEmail) {
+        User user = getUserByEmail(authenticatedEmail);
+        return new UnreadNotificationsResponse(notificationRepository.countByUserIdAndReadAtIsNull(user.getId()));
+    }
+
+    @Override
+    @Transactional
+    public NotificationResponse markAsRead(Long notificationId, String authenticatedEmail) {
+        User user = getUserByEmail(authenticatedEmail);
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, user.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Notificacion no encontrada con id: " + notificationId));
+
+        if (notification.getReadAt() == null) {
+            notification.setReadAt(LocalDateTime.now());
+        }
+        return toResponse(notificationRepository.save(notification));
+    }
+
+    @Override
+    @Transactional
+    public UnreadNotificationsResponse markAllAsRead(String authenticatedEmail) {
+        User user = getUserByEmail(authenticatedEmail);
+        notificationRepository.markAllUnreadAsRead(user.getId(), LocalDateTime.now());
+        return new UnreadNotificationsResponse(0);
+    }
+
+    @Override
+    @Transactional
+    public void notifyLoanCreated(Loan loan) {
+        createOnceForLoan(
+                loan,
+                NotificationType.LOAN_CREATED,
+                "Prestamo creado",
+                "Tu prestamo de \"" + loan.getBook().getTitle()
+                        + "\" fue creado. Vence el " + formatDate(loan.getDueDate()) + ".",
+                "LOAN_CREATED:" + loan.getId());
+        createOnceForStaff(
+                loan.getUser(),
+                NotificationType.LOAN_CREATED,
+                "Nuevo prestamo",
+                loan.getUser().getName() + " tomo prestado \"" + loan.getBook().getTitle()
+                        + "\" hasta el " + formatDate(loan.getDueDate()) + ".",
+                TARGET_LOANS,
+                loan.getId(),
+                "STAFF:LOAN_CREATED:" + loan.getId());
+    }
+
+    @Override
+    @Transactional
+    public void notifyLoanRenewed(Loan loan) {
+        createOnceForLoan(
+                loan,
+                NotificationType.LOAN_RENEWED,
+                "Prestamo renovado",
+                "Tu prestamo de \"" + loan.getBook().getTitle()
+                        + "\" fue renovado hasta el " + formatDate(loan.getDueDate()) + ".",
+                "LOAN_RENEWED:" + loan.getId() + ":" + loan.getDueDate());
+        createOnceForStaff(
+                loan.getUser(),
+                NotificationType.LOAN_RENEWED,
+                "Prestamo renovado",
+                loan.getUser().getName() + " renovo \"" + loan.getBook().getTitle()
+                        + "\" hasta el " + formatDate(loan.getDueDate()) + ".",
+                TARGET_LOANS,
+                loan.getId(),
+                "STAFF:LOAN_RENEWED:" + loan.getId() + ":" + loan.getDueDate());
+    }
+
+    @Override
+    @Transactional
+    public void notifyLoanReturned(Loan loan) {
+        createOnceForLoan(
+                loan,
+                NotificationType.LOAN_RETURNED,
+                "Prestamo devuelto",
+                "Confirmamos la devolucion de \"" + loan.getBook().getTitle() + "\".",
+                "LOAN_RETURNED:" + loan.getId());
+        createOnceForStaff(
+                loan.getUser(),
+                NotificationType.LOAN_RETURNED,
+                "Prestamo devuelto",
+                loan.getUser().getName() + " devolvio \"" + loan.getBook().getTitle() + "\".",
+                TARGET_LOANS,
+                loan.getId(),
+                "STAFF:LOAN_RETURNED:" + loan.getId());
+    }
+
+    @Override
+    @Transactional
+    public void notifyLoanDueSoon(Loan loan) {
+        createOnceForLoan(
+                loan,
+                NotificationType.LOAN_DUE_SOON,
+                "Prestamo por vencer",
+                "Tu prestamo de \"" + loan.getBook().getTitle()
+                        + "\" vence pronto: " + formatDate(loan.getDueDate()) + ".",
+                "LOAN_DUE_SOON:" + loan.getId() + ":" + loan.getDueDate());
+        createOnceForStaff(
+                loan.getUser(),
+                NotificationType.LOAN_DUE_SOON,
+                "Prestamo por vencer",
+                "El prestamo de " + loan.getUser().getName() + " para \""
+                        + loan.getBook().getTitle() + "\" vence el " + formatDate(loan.getDueDate()) + ".",
+                TARGET_LOANS,
+                loan.getId(),
+                "STAFF:LOAN_DUE_SOON:" + loan.getId() + ":" + loan.getDueDate());
+    }
+
+    @Override
+    @Transactional
+    public void notifyLoanOverdue(Loan loan) {
+        createOnceForLoan(
+                loan,
+                NotificationType.LOAN_OVERDUE,
+                "Prestamo vencido",
+                "Tu prestamo de \"" + loan.getBook().getTitle() + "\" ya vencio. Por favor devuelvelo cuanto antes.",
+                "LOAN_OVERDUE:" + loan.getId());
+        createOnceForStaff(
+                loan.getUser(),
+                NotificationType.LOAN_OVERDUE,
+                "Prestamo vencido",
+                "El prestamo de " + loan.getUser().getName() + " para \""
+                        + loan.getBook().getTitle() + "\" esta vencido.",
+                TARGET_LOANS,
+                loan.getId(),
+                "STAFF:LOAN_OVERDUE:" + loan.getId());
+    }
+
+    @Override
+    @Transactional
+    public void notifyReservationCreated(Reservation reservation) {
+        createOnceForReservation(
+                reservation,
+                NotificationType.RESERVATION_CREATED,
+                "Reserva creada",
+                "Tu reserva de \"" + reservation.getBook().getTitle() + "\" quedo en cola.",
+                TARGET_RESERVATIONS,
+                reservation.getId(),
+                "RESERVATION_CREATED:" + reservation.getId());
+        createOnceForStaff(
+                reservation.getUser(),
+                NotificationType.RESERVATION_CREATED,
+                "Nueva reserva",
+                reservation.getUser().getName() + " reservo \"" + reservation.getBook().getTitle() + "\".",
+                TARGET_RESERVATIONS,
+                reservation.getId(),
+                "STAFF:RESERVATION_CREATED:" + reservation.getId());
+    }
+
+    @Override
+    @Transactional
+    public void notifyReservationCancelled(Reservation reservation) {
+        createOnceForReservation(
+                reservation,
+                NotificationType.RESERVATION_CANCELLED,
+                "Reserva cancelada",
+                "Cancelaste tu reserva de \"" + reservation.getBook().getTitle() + "\".",
+                TARGET_RESERVATIONS,
+                reservation.getId(),
+                "RESERVATION_CANCELLED:" + reservation.getId());
+        createOnceForStaff(
+                reservation.getUser(),
+                NotificationType.RESERVATION_CANCELLED,
+                "Reserva cancelada",
+                reservation.getUser().getName() + " cancelo la reserva de \""
+                        + reservation.getBook().getTitle() + "\".",
+                TARGET_RESERVATIONS,
+                reservation.getId(),
+                "STAFF:RESERVATION_CANCELLED:" + reservation.getId());
+    }
+
+    @Override
+    @Transactional
+    public void notifyReservationFulfilled(Reservation reservation) {
+        Long fulfilledLoanId = reservation.getFulfilledLoan() == null ? null : reservation.getFulfilledLoan().getId();
+        createOnceForReservation(
+                reservation,
+                NotificationType.RESERVATION_FULFILLED,
+                "Reserva asignada",
+                "Tu reserva de \"" + reservation.getBook().getTitle() + "\" ya se convirtio en prestamo.",
+                TARGET_LOANS,
+                fulfilledLoanId,
+                "RESERVATION_FULFILLED:" + reservation.getId() + ":" + fulfilledLoanId);
+        createOnceForStaff(
+                reservation.getUser(),
+                NotificationType.RESERVATION_FULFILLED,
+                "Reserva asignada",
+                "La reserva de " + reservation.getUser().getName() + " para \""
+                        + reservation.getBook().getTitle() + "\" se convirtio en prestamo.",
+                TARGET_LOANS,
+                fulfilledLoanId,
+                "STAFF:RESERVATION_FULFILLED:" + reservation.getId() + ":" + fulfilledLoanId);
+    }
+
+    private void createOnceForLoan(
+            Loan loan,
+            NotificationType type,
+            String title,
+            String message,
+            String dedupeKey) {
+        createOnce(loan.getUser(), type, title, message, TARGET_LOANS, loan.getId(), dedupeKey);
+    }
+
+    private void createOnceForReservation(
+            Reservation reservation,
+            NotificationType type,
+            String title,
+            String message,
+            String targetView,
+            Long targetId,
+            String dedupeKey) {
+        createOnce(reservation.getUser(), type, title, message, targetView, targetId, dedupeKey);
+    }
+
+    private void createOnce(
+            User user,
+            NotificationType type,
+            String title,
+            String message,
+            String targetView,
+            Long targetId,
+            String dedupeKey) {
+        if (dedupeKey != null && notificationRepository.existsByDedupeKey(dedupeKey)) {
+            return;
+        }
+
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(type)
+                .title(title)
+                .message(message)
+                .targetView(targetView)
+                .targetId(targetId)
+                .dedupeKey(dedupeKey)
+                .build();
+        notificationRepository.save(notification);
+    }
+
+    private void createOnceForStaff(
+            User subjectUser,
+            NotificationType type,
+            String title,
+            String message,
+            String targetView,
+            Long targetId,
+            String dedupePrefix) {
+        for (User staffUser : userRepository.findAllByRoleUpperIn(STAFF_ROLES)) {
+            if (staffUser.getId().equals(subjectUser.getId())) {
+                continue;
+            }
+            createOnce(
+                    staffUser,
+                    type,
+                    title,
+                    message,
+                    targetView,
+                    targetId,
+                    dedupePrefix + ":" + staffUser.getId());
+        }
+    }
+
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado para el token actual."));
+    }
+
+    private NotificationResponse toResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType().name())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .targetView(notification.getTargetView())
+                .targetId(notification.getTargetId())
+                .readAt(notification.getReadAt())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
+    private String formatDate(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return "sin fecha";
+        }
+        String normalized = dateTime.toString().replace("T", " ");
+        return normalized.length() > 16 ? normalized.substring(0, 16) : normalized;
+    }
+}

--- a/src/main/java/com/lassriver/bookworm/services/impl/ReservationServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/ReservationServiceImpl.java
@@ -15,6 +15,7 @@ import com.lassriver.bookworm.repositories.BookRepository;
 import com.lassriver.bookworm.repositories.LoanRepository;
 import com.lassriver.bookworm.repositories.ReservationRepository;
 import com.lassriver.bookworm.repositories.UserRepository;
+import com.lassriver.bookworm.services.NotificationService;
 import com.lassriver.bookworm.services.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -37,6 +38,7 @@ public class ReservationServiceImpl implements ReservationService {
     private final BookRepository bookRepository;
     private final BookCopyRepository bookCopyRepository;
     private final LoanRepository loanRepository;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -66,7 +68,9 @@ public class ReservationServiceImpl implements ReservationService {
                 .requestedLoanDurationMinutes(request.getRequestedLoanDurationMinutes())
                 .build();
 
-        return toResponse(reservationRepository.save(reservation));
+        Reservation savedReservation = reservationRepository.save(reservation);
+        notificationService.notifyReservationCreated(savedReservation);
+        return toResponse(savedReservation);
     }
 
     @Override
@@ -82,7 +86,9 @@ public class ReservationServiceImpl implements ReservationService {
 
         reservation.setStatus(ReservationStatus.CANCELLED);
         reservation.setCancelledAt(LocalDateTime.now());
-        return toResponse(reservationRepository.save(reservation));
+        Reservation savedReservation = reservationRepository.save(reservation);
+        notificationService.notifyReservationCancelled(savedReservation);
+        return toResponse(savedReservation);
     }
 
     @Override

--- a/src/main/java/com/lassriver/bookworm/services/impl/ReservationServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/ReservationServiceImpl.java
@@ -31,6 +31,7 @@ public class ReservationServiceImpl implements ReservationService {
 
     private static final int MIN_LOAN_DURATION_MINUTES = 5;
     private static final int MAX_LOAN_DURATION_MINUTES = 10_080;
+    private static final int LOAN_COOLDOWN_HOURS = 24;
     private static final List<LoanStatus> OPEN_LOAN_STATUSES = List.of(LoanStatus.ACTIVE, LoanStatus.OVERDUE);
 
     private final ReservationRepository reservationRepository;
@@ -56,6 +57,9 @@ public class ReservationServiceImpl implements ReservationService {
         }
         if (loanRepository.existsByUserIdAndBookIdAndStatusIn(user.getId(), book.getId(), OPEN_LOAN_STATUSES)) {
             throw new BusinessRuleException("Ya tienes un prestamo activo para este libro.");
+        }
+        if (isLoanCooldownActive(user, book)) {
+            throw new BusinessRuleException("Debes esperar 24 horas despues de devolver este libro para volver a reservarlo.");
         }
         if (reservationRepository.existsByUserIdAndBookIdAndStatus(user.getId(), book.getId(), ReservationStatus.WAITING)) {
             throw new BusinessRuleException("Ya tienes una reserva en cola para este libro.");
@@ -116,6 +120,15 @@ public class ReservationServiceImpl implements ReservationService {
 
     private boolean isPrivileged(User user) {
         return "ADMIN".equalsIgnoreCase(user.getRole()) || "LIBRARIAN".equalsIgnoreCase(user.getRole());
+    }
+
+    private boolean isLoanCooldownActive(User user, Book book) {
+        LocalDateTime returnedAfter = LocalDateTime.now().minusHours(LOAN_COOLDOWN_HOURS);
+        return loanRepository.findFirstByUserIdAndBookIdAndStatusAndReturnedAtAfterOrderByReturnedAtDesc(
+                user.getId(),
+                book.getId(),
+                LoanStatus.RETURNED,
+                returnedAfter).isPresent();
     }
 
     private ReservationResponse toResponse(Reservation reservation) {

--- a/src/main/java/com/lassriver/bookworm/services/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/lassriver/bookworm/services/impl/ReviewServiceImpl.java
@@ -73,7 +73,11 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional(readOnly = true)
     public List<ReviewResponse> getReviews(String status) {
         String effectiveStatus = status == null || status.isBlank() ? REVIEW_VISIBLE : status.toUpperCase();
-        return reviewRepository.findAllByStatusOrderByCreatedAtDesc(effectiveStatus)
+        List<Review> reviews = "ALL".equals(effectiveStatus)
+                ? reviewRepository.findAllByOrderByCreatedAtDesc()
+                : reviewRepository.findAllByStatusOrderByCreatedAtDesc(effectiveStatus);
+
+        return reviews
                 .stream()
                 .map(this::toResponse)
                 .toList();

--- a/src/main/resources/db/migration/V9__create_notifications_table.sql
+++ b/src/main/resources/db/migration/V9__create_notifications_table.sql
@@ -1,0 +1,30 @@
+CREATE TABLE notifications (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    type VARCHAR(40) NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    message TEXT NOT NULL,
+    target_view VARCHAR(40),
+    target_id BIGINT,
+    dedupe_key VARCHAR(160),
+    read_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_notifications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT chk_notifications_type CHECK (type IN (
+        'LOAN_CREATED',
+        'LOAN_RENEWED',
+        'LOAN_RETURNED',
+        'LOAN_DUE_SOON',
+        'LOAN_OVERDUE',
+        'RESERVATION_CREATED',
+        'RESERVATION_CANCELLED',
+        'RESERVATION_FULFILLED'
+    ))
+);
+
+CREATE UNIQUE INDEX ux_notifications_dedupe_key
+    ON notifications(dedupe_key)
+    WHERE dedupe_key IS NOT NULL;
+
+CREATE INDEX idx_notifications_user_read ON notifications(user_id, read_at);
+CREATE INDEX idx_notifications_user_created ON notifications(user_id, created_at DESC);

--- a/src/test/java/com/lassriver/bookworm/controllers/NotificationControllerIT.java
+++ b/src/test/java/com/lassriver/bookworm/controllers/NotificationControllerIT.java
@@ -1,0 +1,163 @@
+package com.lassriver.bookworm.controllers;
+
+import com.lassriver.bookworm.BaseSecurityIntegrationTest;
+import com.lassriver.bookworm.entities.Notification;
+import com.lassriver.bookworm.entities.User;
+import com.lassriver.bookworm.entities.enums.NotificationType;
+import com.lassriver.bookworm.repositories.NotificationRepository;
+import com.lassriver.bookworm.repositories.UserRepository;
+import com.lassriver.bookworm.security.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@DisplayName("NotificationController - Tests de Integracion")
+class NotificationControllerIT extends BaseSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User user;
+    private User otherUser;
+    private String userToken;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+        String suffix = String.valueOf(System.nanoTime());
+
+        user = userRepository.save(User.builder()
+                .name("User")
+                .email("notification-user-" + suffix + "@bookworm.com")
+                .password(passwordEncoder.encode("UserPass123!"))
+                .role("USER")
+                .language("es")
+                .build());
+
+        otherUser = userRepository.save(User.builder()
+                .name("Other")
+                .email("notification-other-" + suffix + "@bookworm.com")
+                .password(passwordEncoder.encode("OtherPass123!"))
+                .role("USER")
+                .language("es")
+                .build());
+
+        userToken = jwtService.generateToken(user);
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications - lista solo notificaciones del usuario autenticado")
+    void getNotifications_ReturnsOnlyAuthenticatedUserNotifications() throws Exception {
+        notificationRepository.save(Notification.builder()
+                .user(user)
+                .type(NotificationType.LOAN_CREATED)
+                .title("Prestamo creado")
+                .message("Mensaje")
+                .targetView("loans")
+                .targetId(1L)
+                .build());
+        notificationRepository.save(Notification.builder()
+                .user(otherUser)
+                .type(NotificationType.LOAN_CREATED)
+                .title("Otra notificacion")
+                .message("Mensaje")
+                .targetView("loans")
+                .targetId(2L)
+                .build());
+
+        mockMvc.perform(get("/api/notifications")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].title", is("Prestamo creado")))
+                .andExpect(jsonPath("$.totalElements", is(1)));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications/unread-count - devuelve contador de no leidas")
+    void getUnreadCount_ReturnsUnreadCount() throws Exception {
+        Notification readNotification = Notification.builder()
+                .user(user)
+                .type(NotificationType.LOAN_CREATED)
+                .title("Leida")
+                .message("Mensaje")
+                .readAt(java.time.LocalDateTime.now())
+                .build();
+        Notification unreadNotification = Notification.builder()
+                .user(user)
+                .type(NotificationType.LOAN_OVERDUE)
+                .title("No leida")
+                .message("Mensaje")
+                .build();
+        notificationRepository.save(readNotification);
+        notificationRepository.save(unreadNotification);
+
+        mockMvc.perform(get("/api/notifications/unread-count")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.unreadCount", is(1)));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/notifications/{id}/read - marca como leida una notificacion propia")
+    void markAsRead_WhenOwnNotification_ReturnsUpdatedNotification() throws Exception {
+        Notification notification = notificationRepository.save(Notification.builder()
+                .user(user)
+                .type(NotificationType.RESERVATION_CREATED)
+                .title("Reserva creada")
+                .message("Mensaje")
+                .targetView("reservations")
+                .build());
+
+        mockMvc.perform(patch("/api/notifications/{id}/read", notification.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.readAt", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/notifications/{id}/read - 404 si pertenece a otro usuario")
+    void markAsRead_WhenOtherUserNotification_Returns404() throws Exception {
+        Notification notification = notificationRepository.save(Notification.builder()
+                .user(otherUser)
+                .type(NotificationType.RESERVATION_CREATED)
+                .title("Reserva creada")
+                .message("Mensaje")
+                .targetView("reservations")
+                .build());
+
+        mockMvc.perform(patch("/api/notifications/{id}/read", notification.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code", is("NOT_FOUND")));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications - 401 cuando no hay token")
+    void getNotifications_WithoutToken_Returns401() throws Exception {
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/lassriver/bookworm/services/impl/BookCopyServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/BookCopyServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.lassriver.bookworm.services.impl;
+
+import com.lassriver.bookworm.dtos.response.BookCopyResponse;
+import com.lassriver.bookworm.entities.Book;
+import com.lassriver.bookworm.entities.BookCopy;
+import com.lassriver.bookworm.entities.enums.BookCopyStatus;
+import com.lassriver.bookworm.entities.enums.ReservationStatus;
+import com.lassriver.bookworm.exceptions.BusinessRuleException;
+import com.lassriver.bookworm.repositories.BookCopyRepository;
+import com.lassriver.bookworm.repositories.BookRepository;
+import com.lassriver.bookworm.repositories.ReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookCopyServiceImplTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private BookCopyRepository bookCopyRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private BookCopyServiceImpl bookCopyService;
+
+    @Test
+    void retireCopy_WhenAvailableAndNoQueue_RetiresCopy() {
+        Book book = book();
+        BookCopy copy = copy(book, BookCopyStatus.AVAILABLE);
+        when(bookRepository.findLockedById(1L)).thenReturn(Optional.of(book));
+        when(bookCopyRepository.findByIdAndBookId(10L, 1L)).thenReturn(Optional.of(copy));
+        when(reservationRepository.existsByBookIdAndStatus(1L, ReservationStatus.WAITING)).thenReturn(false);
+        when(bookCopyRepository.countByBookIdAndStatusIn(eq(1L), anyCollection())).thenReturn(2L);
+        when(bookCopyRepository.save(copy)).thenReturn(copy);
+
+        BookCopyResponse response = bookCopyService.retireCopy(1L, 10L);
+
+        assertEquals("INACTIVE", response.getStatus());
+        assertEquals(BookCopyStatus.INACTIVE, copy.getStatus());
+        verify(bookCopyRepository).save(copy);
+    }
+
+    @Test
+    void retireCopy_WhenWaitingReservationsExist_ThrowsBusinessRuleException() {
+        Book book = book();
+        BookCopy copy = copy(book, BookCopyStatus.AVAILABLE);
+        when(bookRepository.findLockedById(1L)).thenReturn(Optional.of(book));
+        when(bookCopyRepository.findByIdAndBookId(10L, 1L)).thenReturn(Optional.of(copy));
+        when(reservationRepository.existsByBookIdAndStatus(1L, ReservationStatus.WAITING)).thenReturn(true);
+
+        assertThrows(BusinessRuleException.class, () -> bookCopyService.retireCopy(1L, 10L));
+
+        verify(bookCopyRepository, never()).save(copy);
+    }
+
+    @Test
+    void retireCopy_WhenCopyIsNotAvailable_ThrowsBusinessRuleException() {
+        Book book = book();
+        BookCopy copy = copy(book, BookCopyStatus.LOANED);
+        when(bookRepository.findLockedById(1L)).thenReturn(Optional.of(book));
+        when(bookCopyRepository.findByIdAndBookId(10L, 1L)).thenReturn(Optional.of(copy));
+        when(reservationRepository.existsByBookIdAndStatus(1L, ReservationStatus.WAITING)).thenReturn(false);
+
+        assertThrows(BusinessRuleException.class, () -> bookCopyService.retireCopy(1L, 10L));
+
+        verify(bookCopyRepository, never()).save(copy);
+    }
+
+    @Test
+    void retireCopy_WhenLastCountedCopy_ThrowsBusinessRuleException() {
+        Book book = book();
+        BookCopy copy = copy(book, BookCopyStatus.AVAILABLE);
+        when(bookRepository.findLockedById(1L)).thenReturn(Optional.of(book));
+        when(bookCopyRepository.findByIdAndBookId(10L, 1L)).thenReturn(Optional.of(copy));
+        when(reservationRepository.existsByBookIdAndStatus(1L, ReservationStatus.WAITING)).thenReturn(false);
+        when(bookCopyRepository.countByBookIdAndStatusIn(eq(1L), anyCollection())).thenReturn(1L);
+
+        assertThrows(BusinessRuleException.class, () -> bookCopyService.retireCopy(1L, 10L));
+
+        verify(bookCopyRepository, never()).save(copy);
+    }
+
+    private Book book() {
+        return Book.builder()
+                .id(1L)
+                .title("Clean Architecture")
+                .author("Robert Martin")
+                .isbn("ISBN-001")
+                .status("ACTIVE")
+                .build();
+    }
+
+    private BookCopy copy(Book book, BookCopyStatus status) {
+        return BookCopy.builder()
+                .id(10L)
+                .book(book)
+                .copyCode("BOOK-1-COPY-1")
+                .status(status)
+                .build();
+    }
+}

--- a/src/test/java/com/lassriver/bookworm/services/impl/LoanServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/LoanServiceImplTest.java
@@ -127,6 +127,32 @@ class LoanServiceImplTest {
     }
 
     @Test
+    void createLoan_WhenBookWasRecentlyReturned_ThrowsBusinessRuleException() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        Book book = Book.builder().id(10L).status("ACTIVE").build();
+        Loan returnedLoan = Loan.builder()
+                .id(77L)
+                .user(user)
+                .book(book)
+                .status(LoanStatus.RETURNED)
+                .returnedAt(LocalDateTime.now().minusHours(2))
+                .build();
+        LoanCreateRequest request = new LoanCreateRequest();
+        request.setBookId(10L);
+        request.setDurationMinutes(60);
+
+        when(userRepository.findByEmail("user@bookworm.com")).thenReturn(Optional.of(user));
+        when(bookRepository.findLockedById(10L)).thenReturn(Optional.of(book));
+        when(loanRepository.existsByUserIdAndBookIdAndStatusIn(eq(1L), eq(10L), any())).thenReturn(false);
+        when(loanRepository.findFirstByUserIdAndBookIdAndStatusAndReturnedAtAfterOrderByReturnedAtDesc(
+                eq(1L), eq(10L), eq(LoanStatus.RETURNED), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(returnedLoan));
+
+        assertThrows(BusinessRuleException.class, () -> loanService.createLoan(request, "user@bookworm.com"));
+        verify(loanRepository, never()).save(any(Loan.class));
+    }
+
+    @Test
     void returnLoan_WhenLoanIsFromAnotherUser_ThrowsAccessDeniedException() {
         User requester = User.builder().id(1L).email("user@bookworm.com").build();
         User owner = User.builder().id(2L).email("other@bookworm.com").build();

--- a/src/test/java/com/lassriver/bookworm/services/impl/LoanServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/LoanServiceImplTest.java
@@ -16,6 +16,7 @@ import com.lassriver.bookworm.repositories.LoanRenewalRepository;
 import com.lassriver.bookworm.repositories.LoanRepository;
 import com.lassriver.bookworm.repositories.ReservationRepository;
 import com.lassriver.bookworm.repositories.UserRepository;
+import com.lassriver.bookworm.services.NotificationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -52,6 +53,9 @@ class LoanServiceImplTest {
     @Mock
     private LoanRenewalRepository loanRenewalRepository;
 
+    @Mock
+    private NotificationService notificationService;
+
     @InjectMocks
     private LoanServiceImpl loanService;
 
@@ -87,6 +91,7 @@ class LoanServiceImplTest {
         assertEquals(100L, response.getId());
         assertEquals("ACTIVE", response.getStatus());
         assertEquals(10L, response.getBookId());
+        verify(notificationService).notifyLoanCreated(savedLoan);
     }
 
     @Test

--- a/src/test/java/com/lassriver/bookworm/services/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/NotificationServiceImplTest.java
@@ -1,0 +1,162 @@
+package com.lassriver.bookworm.services.impl;
+
+import com.lassriver.bookworm.dtos.response.NotificationResponse;
+import com.lassriver.bookworm.dtos.response.PageResponse;
+import com.lassriver.bookworm.entities.Book;
+import com.lassriver.bookworm.entities.Loan;
+import com.lassriver.bookworm.entities.Notification;
+import com.lassriver.bookworm.entities.User;
+import com.lassriver.bookworm.entities.enums.LoanStatus;
+import com.lassriver.bookworm.entities.enums.NotificationType;
+import com.lassriver.bookworm.exceptions.BusinessRuleException;
+import com.lassriver.bookworm.exceptions.ResourceNotFoundException;
+import com.lassriver.bookworm.repositories.NotificationRepository;
+import com.lassriver.bookworm.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Test
+    void getMyNotifications_WhenUnreadFilter_ReturnsOnlyUnreadPage() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        Notification notification = Notification.builder()
+                .id(10L)
+                .user(user)
+                .type(NotificationType.LOAN_DUE_SOON)
+                .title("Prestamo por vencer")
+                .message("Mensaje")
+                .createdAt(LocalDateTime.now())
+                .build();
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        when(userRepository.findByEmail("user@bookworm.com")).thenReturn(Optional.of(user));
+        when(notificationRepository.findAllByUserIdAndReadAtIsNullOrderByCreatedAtDesc(1L, pageable))
+                .thenReturn(new PageImpl<>(List.of(notification), pageable, 1));
+
+        PageResponse<NotificationResponse> response =
+                notificationService.getMyNotifications("user@bookworm.com", "unread", pageable);
+
+        assertEquals(1, response.getTotalElements());
+        assertEquals(NotificationType.LOAN_DUE_SOON.name(), response.getContent().getFirst().getType());
+    }
+
+    @Test
+    void getMyNotifications_WhenInvalidStatus_ThrowsBusinessRuleException() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        when(userRepository.findByEmail("user@bookworm.com")).thenReturn(Optional.of(user));
+
+        assertThrows(
+                BusinessRuleException.class,
+                () -> notificationService.getMyNotifications("user@bookworm.com", "archived", pageable));
+    }
+
+    @Test
+    void markAsRead_WhenNotificationBelongsToUser_SetsReadAt() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        Notification notification = Notification.builder()
+                .id(10L)
+                .user(user)
+                .type(NotificationType.LOAN_CREATED)
+                .title("Prestamo creado")
+                .message("Mensaje")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userRepository.findByEmail("user@bookworm.com")).thenReturn(Optional.of(user));
+        when(notificationRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(notification));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationResponse response = notificationService.markAsRead(10L, "user@bookworm.com");
+
+        assertNotNull(response.getReadAt());
+        verify(notificationRepository).save(notification);
+    }
+
+    @Test
+    void markAsRead_WhenNotificationDoesNotBelongToUser_ThrowsResourceNotFoundException() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+
+        when(userRepository.findByEmail("user@bookworm.com")).thenReturn(Optional.of(user));
+        when(notificationRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> notificationService.markAsRead(10L, "user@bookworm.com"));
+    }
+
+    @Test
+    void notifyLoanCreated_WhenDedupeKeyDoesNotExist_SavesNotification() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        Book book = Book.builder().id(20L).title("Clean Code").build();
+        Loan loan = Loan.builder()
+                .id(30L)
+                .user(user)
+                .book(book)
+                .status(LoanStatus.ACTIVE)
+                .dueDate(LocalDateTime.now().plusHours(1))
+                .build();
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        when(notificationRepository.existsByDedupeKey("LOAN_CREATED:30")).thenReturn(false);
+        when(userRepository.findAllByRoleUpperIn(any())).thenReturn(List.of());
+
+        notificationService.notifyLoanCreated(loan);
+
+        verify(notificationRepository).save(captor.capture());
+        assertEquals(user, captor.getValue().getUser());
+        assertEquals(NotificationType.LOAN_CREATED, captor.getValue().getType());
+        assertEquals("loans", captor.getValue().getTargetView());
+        assertEquals(30L, captor.getValue().getTargetId());
+    }
+
+    @Test
+    void notifyLoanReturned_WhenStaffUsersExist_SavesStaffNotification() {
+        User borrower = User.builder().id(1L).name("Kevin").email("user@bookworm.com").role("USER").build();
+        User admin = User.builder().id(2L).name("Admin").email("admin@bookworm.com").role("ADMIN").build();
+        Book book = Book.builder().id(20L).title("Clean Code").build();
+        Loan loan = Loan.builder()
+                .id(30L)
+                .user(borrower)
+                .book(book)
+                .status(LoanStatus.RETURNED)
+                .dueDate(LocalDateTime.now().plusHours(1))
+                .build();
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+
+        when(notificationRepository.existsByDedupeKey(any())).thenReturn(false);
+        when(userRepository.findAllByRoleUpperIn(any())).thenReturn(List.of(admin));
+
+        notificationService.notifyLoanReturned(loan);
+
+        verify(notificationRepository, times(2)).save(captor.capture());
+        Notification staffNotification = captor.getAllValues().get(1);
+        assertEquals(admin, staffNotification.getUser());
+        assertEquals(NotificationType.LOAN_RETURNED, staffNotification.getType());
+        assertEquals("STAFF:LOAN_RETURNED:30:2", staffNotification.getDedupeKey());
+    }
+}

--- a/src/test/java/com/lassriver/bookworm/services/impl/ReviewServiceImplTest.java
+++ b/src/test/java/com/lassriver/bookworm/services/impl/ReviewServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -119,5 +120,21 @@ class ReviewServiceImplTest {
         ReviewResponse response = reviewService.hideReview(99L);
 
         assertEquals("HIDDEN", response.getStatus());
+    }
+
+    @Test
+    void getReviews_WhenStatusAll_ReturnsVisibleAndHiddenReviews() {
+        User user = User.builder().id(1L).email("user@bookworm.com").build();
+        Book book = Book.builder().id(10L).title("Book").build();
+        Review visible = Review.builder().id(1L).user(user).book(book).rating(5).comment("x").status("VISIBLE").build();
+        Review hidden = Review.builder().id(2L).user(user).book(book).rating(3).comment("y").status("HIDDEN").build();
+
+        when(reviewRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(hidden, visible));
+
+        List<ReviewResponse> response = reviewService.getReviews("ALL");
+
+        assertEquals(2, response.size());
+        assertEquals("HIDDEN", response.getFirst().getStatus());
+        verify(reviewRepository, never()).findAllByStatusOrderByCreatedAtDesc(any());
     }
 }


### PR DESCRIPTION
## Description
Adds persistent in-app notifications for transactional library workflows.

## Changes Made
- Added notifications table, entity, repository, service and controller
- Added unread count, list, mark-read and mark-all-read endpoints
- Created loan and reservation notifications for users, admins and librarians
- Added due-soon and overdue scheduled notification workflow
- Added admin review listing support for all statuses
- Added unit and integration coverage for notification/review behavior

## Testing
- [x] mvnw test
- [x] mvnw verify

Note: Integration tests compile and are part of verify, but Testcontainers tests are skipped locally when Docker is unavailable.