### PR TITLE
fix: make database configuration global in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,7 @@
 spring:
   profiles:
-    active: dev # Aquí defines qué perfil usar (HU-T03-02)
-
----
-spring:
+    active: dev # Perfil activo por defecto
   config:
-    activate:
-      on-profile: dev
     import: optional:file:env.properties
   security:
     user:
@@ -25,12 +20,12 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-  
 
 logging:
-    level:
-      '[org.springframework.security]': DEBUG
-      '[org.hibernate.SQL]': DEBUG
+  level:
+    '[org.springframework.security]': DEBUG
+    '[org.hibernate.SQL]': DEBUG
+
 # Configuración para Swagger / OpenAPI (HU-T02-04)
 springdoc:
   swagger-ui:
@@ -45,3 +40,4 @@ bookworm:
     base-url: ${BOOKWORM_AI_BASE_URL:https://api.deepseek.com}
     api-key: ${DEEPSEEK_API_KEY:}
     model: ${BOOKWORM_AI_MODEL:deepseek-v4-flash}
+


### PR DESCRIPTION
## Description
Fixes the issue where the Spring Boot application fails to boot in the 'prod' profile because all datasource properties were nested under the 'on-profile: dev' document separator block.

## Changes Made
- Removed the '---' document separator and 'on-profile: dev' gating in application.yml
- Made Spring datasource, jpa, flyway, logging and bookworm config global so they are loaded on both 'dev' and 'prod' profiles.